### PR TITLE
feat: Add filter by manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           # microsoft_teams_webhook: ${{ secrets.MICROSOFT_TEAMS_WEBHOOK }}
           # slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
           # severity: low,medium
+          # manifest: path-one/,path-two/deeper/
           # count: 20
           # pager_duty_integration_key: ${{ secrets.PAGER_DUTY_INTEGRATION_KEY }}
           # zenduty_api_key: ${{ secrets.ZENDUTY_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,8 @@ inputs:
     default: 20
   severity:
     description: 'Comma separated list of severities. E.g. low,medium,high,critical (NO SPACES BETWEEN COMMA AND SEVERITY)'
+  manifest:
+    description: "A comma-separated list of full manifest paths. If specified, only alerts for these manifests will be returned."
 branding:
   icon: 'alert-octagon'
   color: 'red'

--- a/src/fetch-alerts.ts
+++ b/src/fetch-alerts.ts
@@ -8,6 +8,7 @@ export const fetchAlerts = async (
   repositoryName: string,
   repositoryOwner: string,
   severity: string,
+  manifest: string,
   count: number,
 ): Promise<Alert[] | []> => {
   const octokit = new Octokit({
@@ -20,6 +21,7 @@ export const fetchAlerts = async (
     owner: repositoryOwner,
     repo: repositoryName,
     severity,
+    manifest,
     per_page: count,
   })
   const alerts: Alert[] = response.data

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,9 +31,10 @@ async function run(): Promise<void> {
     const emailTransportSmtpPassword = getInput('email_transport_smtp_password')
     const count = parseInt(getInput('count'))
     const severity = getInput('severity')
+    const manifest = getInput('manifest')
     const owner = context.repo.owner
     const repo = context.repo.repo
-    const alerts = await fetchAlerts(token, repo, owner, severity, count)
+    const alerts = await fetchAlerts(token, repo, owner, severity, manifest, count)
     if (alerts.length > 0) {
       if (microsoftTeamsWebhookUrl) {
         await sendAlertsToMicrosoftTeams(microsoftTeamsWebhookUrl, alerts)


### PR DESCRIPTION
Adding a filter by manifest is quite useful when working in a monorepo.

(Not tested if this is working as intended)