### PR TITLE
feat: Fetch alerts with open status only

### DIFF
--- a/src/entities/alert.ts
+++ b/src/entities/alert.ts
@@ -33,13 +33,3 @@ export const toAlert = (
     : undefined,
   createdAt: dependabotAlert.created_at,
 })
-
-export const isActiveAlert = (dependabotAlert: DependabotAlert): boolean => {
-  if (
-    dependabotAlert.dismissed_at === null &&
-    dependabotAlert.fixed_at === null
-  ) {
-    return true
-  }
-  return false
-}

--- a/src/fetch-alerts.ts
+++ b/src/fetch-alerts.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/rest'
 
-import { Alert, isActiveAlert, toAlert } from './entities'
+import { Alert, toAlert } from './entities'
 
 export const fetchAlerts = async (
   gitHubPersonalAccessToken: string,
@@ -18,13 +18,12 @@ export const fetchAlerts = async (
   const response = await octokit.dependabot.listAlertsForRepo({
     owner: repositoryOwner,
     repo: repositoryName,
+    state: 'open',
     severity,
     per_page: count,
   })
-  const alerts: Alert[] = response.data
-    .filter((dependabotAlert) => isActiveAlert(dependabotAlert))
-    .map((dependabotAlert) =>
-      toAlert(dependabotAlert, repositoryName, repositoryOwner),
-    )
+  const alerts: Alert[] = response.data.map((dependabotAlert) =>
+    toAlert(dependabotAlert, repositoryName, repositoryOwner),
+  )
   return alerts
 }


### PR DESCRIPTION
The existing call returns the first `count` alerts. Some of these alerts may be fixed or dismissed, while there may be older open alerts which were not returned. Moving the filter operation to the backend resolves this problem.

N.B. Alert `state` is one of `auto_dismissed`, `dismissed`, `fixed`, and `open`. Of these, we are only interested in `open`