### PR TITLE
fix: resolve ESLint errors in test files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        project: true,
+        project: './tsconfig.eslint.json',
       },
     },
     settings: {

--- a/tests/destinations/email.test.ts
+++ b/tests/destinations/email.test.ts
@@ -3,7 +3,6 @@ import SMTPTransport from 'nodemailer/lib/smtp-transport'
 
 import { ACTION_SHORT_SUMMARY } from '../../src/constants'
 import { Alert } from '../../src/entities'
-
 import { sendAlertsToEmailSmtp } from '../../src/destinations/email'
 
 const mockSendMail = vi.fn().mockResolvedValue(undefined)

--- a/tests/destinations/pager-duty.test.ts
+++ b/tests/destinations/pager-duty.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest'
 
 import { ACTION_ICON, ACTION_SHORT_SUMMARY, ACTION_URL } from '../../src/constants'
 import { Alert } from '../../src/entities'
-
 import { sendAlertsToPagerDuty } from '../../src/destinations/pager-duty'
 
 const mockEvent = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))

--- a/tests/destinations/slack.test.ts
+++ b/tests/destinations/slack.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 
 import { Alert } from '../../src/entities'
-
 import { sendAlertsToSlack, validateSlackWebhookUrl } from '../../src/destinations/slack'
 
 // Split to avoid triggering secret-scanning heuristics on the hooks.slack.com pattern

--- a/tests/destinations/zenduty.test.ts
+++ b/tests/destinations/zenduty.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest'
 
 import { Alert } from '../../src/entities'
 import { request } from '../../src/utils'
-
 import { sendAlertsToZenduty } from '../../src/destinations/zenduty'
 
 vi.mock('../../src/utils', () => ({

--- a/tests/fetch-alerts.test.ts
+++ b/tests/fetch-alerts.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   DependabotAlert,
   DependabotOrgAlert,
-  DependabotEnterpriseAlert,
 } from '../src/entities/alert'
 import { fetchRepositoryAlerts, fetchOrgAlerts, fetchEnterpriseAlerts } from '../src/fetch-alerts'
 
@@ -49,7 +48,7 @@ const mockRawAlert: DependabotAlert = {
   auto_dismissed_at: null,
 }
 
-const mockRawOrgEnterpriseAlert: DependabotOrgAlert & DependabotEnterpriseAlert = {
+const mockRawOrgEnterpriseAlert: DependabotOrgAlert = {
   ...mockRawAlert,
   repository: {
     id: 1,

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./"
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["./lib", "./node_modules", "./__tests__", "./coverage"]
+}


### PR DESCRIPTION
## Summary
- Add `tsconfig.eslint.json` that includes `tests/` (excluded from main `tsconfig.json`) so ESLint can parse test files
- Point `parserOptions.project` at `tsconfig.eslint.json` instead of `true`
- Fix `import-x/order` errors (stray empty lines within import groups) in destination test files
- Remove duplicate intersection type `DependabotOrgAlert & DependabotEnterpriseAlert` in `fetch-alerts.test.ts`

## Test plan
- [ ] `npx eslint tests/**/*.ts src/**/*.ts` passes with no errors
- [ ] `npm test` passes (48 tests across 9 files)