### PR TITLE
feat: support Zenduty integration key alongside existing API token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,14 @@ inputs:
     description: 'Slack Webhook URL. More info: https://api.slack.com/messaging/webhooks'
   pager_duty_integration_key:
     description: 'Pager Duty Integration Key. More info: https://support.pagerduty.com/docs/services-and-integrations'
+  zenduty_integration_key:
+    description: 'Zenduty Integration Key (preferred). Create a Generic Integration in your Zenduty service to get this key: https://docs.zenduty.com/docs/integrations/integrations'
   zenduty_api_key:
-    description: 'Create a Zenduty API Key by visiting Account Settings > API Keys'
+    description: 'Zenduty API Key (deprecated, use zenduty_integration_key instead). Create one by visiting Account Settings > API Keys'
   zenduty_service_id:
-    description: 'Zenduty Service ID: https://docs.zenduty.com/docs/services'
+    description: 'Zenduty Service ID (only required when using zenduty_api_key): https://docs.zenduty.com/docs/services'
   zenduty_escalation_policy_id:
-    description: 'Zenduty Escalation Policy ID: https://docs.zenduty.com/docs/escalationpolicies'
+    description: 'Zenduty Escalation Policy ID (only required when using zenduty_api_key): https://docs.zenduty.com/docs/escalationpolicies'
   email_from:
     description: 'Sender email'
   email_list:
@@ -37,14 +39,14 @@ inputs:
     default: 'smtp.gmail.com'
   email_transport_smtp_port:
     description: 'SMTP port'
-    default: 587
+    default: '587'
   email_transport_smtp_user:
     description: 'SMTP user'
   email_transport_smtp_password:
     description: 'SMTP password'
   count:
     description: 'Number of vulnerability alerts to send'
-    default: 20
+    default: '20'
   severity:
     description: 'Comma separated list of severities. E.g. low,medium,high,critical (NO SPACES BETWEEN COMMA AND SEVERITY)'
   ecosystem:

--- a/src/destinations/zenduty.ts
+++ b/src/destinations/zenduty.ts
@@ -2,13 +2,7 @@ import { ACTION_SHORT_SUMMARY } from '../constants'
 import { Alert, getFullRepositoryNameFromAlert } from '../entities'
 import { request } from '../utils'
 
-export const sendAlertsToZenduty = async (
-  apiKey: string,
-  serviceId: string,
-  escalationPolicyId: string,
-  alerts: Alert[],
-): Promise<void> => {
-  if (alerts.length === 0) return
+const buildSummary = (alerts: Alert[]): string => {
   let summary = `
     You have ${alerts.length} vulnerabilities in ${alerts[0].repository.owner}/${alerts[0].repository.name}
 
@@ -25,25 +19,49 @@ export const sendAlertsToZenduty = async (
       Summary: ${alert.advisory?.summary}
     `
   })
-
   summary += `
 
     ---
   `
-  const payload = {
-    service: serviceId,
-    escalation_policy: escalationPolicyId,
-    title: `${ACTION_SHORT_SUMMARY} - ${alerts[0].repository.name}`,
-    urgency: 0,
-    summary,
-  }
-  const bearer = `Token ${apiKey}`
+  return summary
+}
+
+export const sendAlertsToZendutyViaIntegration = async (
+  integrationKey: string,
+  alerts: Alert[],
+): Promise<void> => {
+  if (alerts.length === 0) return
+  await request(`https://events.zenduty.com/api/events/${integrationKey}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: `${ACTION_SHORT_SUMMARY} - ${alerts[0].repository.name}`,
+      alert_type: 'critical',
+      summary: buildSummary(alerts),
+      payload: { alerts },
+    }),
+  })
+}
+
+export const sendAlertsToZenduty = async (
+  apiKey: string,
+  serviceId: string,
+  escalationPolicyId: string,
+  alerts: Alert[],
+): Promise<void> => {
+  if (alerts.length === 0) return
   await request('https://www.zenduty.com/api/incidents/', {
     method: 'POST',
     headers: {
-      Authorization: bearer,
+      Authorization: `Token ${apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload),
+    body: JSON.stringify({
+      service: serviceId,
+      escalation_policy: escalationPolicyId,
+      title: `${ACTION_SHORT_SUMMARY} - ${alerts[0].repository.name}`,
+      urgency: 0,
+      summary: buildSummary(alerts),
+    }),
   })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
   sendAlertsToPagerDuty,
   sendAlertsToSlack,
   sendAlertsToZenduty,
+  sendAlertsToZendutyViaIntegration,
   sendAlertsToEmailSes,
   sendAlertsToEmailSmtp,
   validateSlackWebhookUrl,
@@ -25,6 +26,7 @@ async function run(): Promise<void> {
     const microsoftTeamsWebhookUrl = getInput('microsoft_teams_webhook')
     const slackWebhookUrl = getInput('slack_webhook')
     const pagerDutyIntegrationKey = getInput('pager_duty_integration_key')
+    const zenDutyIntegrationKey = getInput('zenduty_integration_key')
     const zenDutyApiKey = getInput('zenduty_api_key')
     const zenDutyServiceId = getInput('zenduty_service_id')
     const zenDutyEscalationPolicyId = getInput('zenduty_escalation_policy_id')
@@ -81,7 +83,9 @@ async function run(): Promise<void> {
       if (pagerDutyIntegrationKey) {
         await sendAlertsToPagerDuty(pagerDutyIntegrationKey, alerts)
       }
-      if (zenDutyApiKey) {
+      if (zenDutyIntegrationKey) {
+        await sendAlertsToZendutyViaIntegration(zenDutyIntegrationKey, alerts)
+      } else if (zenDutyApiKey) {
         if (zenDutyServiceId && zenDutyEscalationPolicyId) {
           await sendAlertsToZenduty(
             zenDutyApiKey,

--- a/tests/destinations/zenduty.test.ts
+++ b/tests/destinations/zenduty.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { Alert } from '../../src/entities'
 import { request } from '../../src/utils'
-import { sendAlertsToZenduty } from '../../src/destinations/zenduty'
+import { sendAlertsToZenduty, sendAlertsToZendutyViaIntegration } from '../../src/destinations/zenduty'
 
 vi.mock('../../src/utils', () => ({
   request: vi.fn().mockResolvedValue(undefined),
@@ -28,6 +28,42 @@ const mockAlert: Alert = {
   },
   createdAt: '2021-01-01T00:00:00Z',
 }
+
+describe('sendAlertsToZendutyViaIntegration', () => {
+  beforeEach(() => mockRequest.mockClear())
+
+  it('does nothing when alerts array is empty', async () => {
+    await sendAlertsToZendutyViaIntegration('int-key', [])
+    expect(mockRequest).not.toHaveBeenCalled()
+  })
+
+  it('posts to the Zenduty events endpoint with the integration key in the URL', async () => {
+    await sendAlertsToZendutyViaIntegration('int-key', [mockAlert])
+    expect(mockRequest).toHaveBeenCalledWith(
+      'https://events.zenduty.com/api/events/int-key/',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('sends no Authorization header', async () => {
+    await sendAlertsToZendutyViaIntegration('int-key', [mockAlert])
+    const options = mockRequest.mock.calls[0][1]
+    expect((options!.headers as Record<string, string>).Authorization).toBeUndefined()
+  })
+
+  it('sets alert_type to critical', async () => {
+    await sendAlertsToZendutyViaIntegration('int-key', [mockAlert])
+    const body = JSON.parse(mockRequest.mock.calls[0][1]!.body as string)
+    expect(body.alert_type).toBe('critical')
+  })
+
+  it('includes package and severity in the summary', async () => {
+    await sendAlertsToZendutyViaIntegration('int-key', [mockAlert])
+    const body = JSON.parse(mockRequest.mock.calls[0][1]!.body as string)
+    expect(body.summary).toContain('lodash')
+    expect(body.summary).toContain('CRITICAL')
+  })
+})
 
 describe('sendAlertsToZenduty', () => {
   it('does nothing when alerts array is empty', async () => {


### PR DESCRIPTION
## Summary
- Add `zenduty_integration_key` input that uses the Zenduty Events API (`https://events.zenduty.com/api/events/<key>/`) — no auth header needed, just the key in the URL
- When `zenduty_integration_key` is provided it takes precedence; falls back to the existing `zenduty_api_key` + `zenduty_service_id` + `zenduty_escalation_policy_id` path for backwards compatibility
- Mark the old inputs as deprecated in `action.yml` descriptions
- Fix `action.yml` numeric defaults (`587`, `20`) to strings as required by the schema
- Add 5 tests covering the new integration key path

No breaking changes — existing users are unaffected.

Closes #135

## Test plan
- [ ] `npm test` passes (58 tests across 9 files)
- [ ] `npm run build` passes with no type errors
- [ ] `npx eslint src/**/*.ts tests/**/*.ts` passes with no errors