### PR TITLE
feat: add ignore input to suppress alerts for specific packages

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,8 @@ inputs:
     description: 'Comma separated list of severities. E.g. low,medium,high,critical (NO SPACES BETWEEN COMMA AND SEVERITY)'
   ecosystem:
     description: 'A comma-separated list of ecosystems. If specified, only alerts for these ecosystems will be returned.'
+  ignore:
+    description: 'Comma-separated list of package names to ignore. E.g. lodash,axios (NO SPACES BETWEEN COMMA AND PACKAGE NAME)'
 branding:
   icon: 'alert-octagon'
   color: 'red'

--- a/src/fetch-alerts.ts
+++ b/src/fetch-alerts.ts
@@ -7,6 +7,11 @@ import {
   toEnterpriseAlert,
 } from './entities'
 
+export const filterIgnoredAlerts = (alerts: Alert[], ignoreList: string[]): Alert[] => {
+  if (ignoreList.length === 0) return alerts
+  return alerts.filter((alert) => !ignoreList.includes(alert.packageName))
+}
+
 export const fetchRepositoryAlerts = async (
   gitHubPersonalAccessToken: string,
   repositoryName: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
   fetchRepositoryAlerts,
   fetchOrgAlerts,
   fetchEnterpriseAlerts,
+  filterIgnoredAlerts,
 } from './fetch-alerts'
 import { Alert } from './entities'
 
@@ -46,6 +47,8 @@ async function run(): Promise<void> {
     const count = parseInt(getInput('count'), 10)
     const severity = getInput('severity')
     const ecosystem = getInput('ecosystem')
+    const ignore = getInput('ignore')
+    const ignoreList = ignore ? ignore.split(',') : []
 
     let alerts: Alert[] = []
     if (org) {
@@ -69,6 +72,7 @@ async function run(): Promise<void> {
         count,
       )
     }
+    alerts = filterIgnoredAlerts(alerts, ignoreList)
     if (alerts.length > 0) {
       if (microsoftTeamsWebhookUrl) {
         await sendAlertsToMicrosoftTeams(microsoftTeamsWebhookUrl, alerts)

--- a/tests/fetch-alerts.test.ts
+++ b/tests/fetch-alerts.test.ts
@@ -4,7 +4,7 @@ import {
   DependabotAlert,
   DependabotOrgAlert,
 } from '../src/entities/alert'
-import { fetchRepositoryAlerts, fetchOrgAlerts, fetchEnterpriseAlerts } from '../src/fetch-alerts'
+import { fetchRepositoryAlerts, fetchOrgAlerts, fetchEnterpriseAlerts, filterIgnoredAlerts } from '../src/fetch-alerts'
 
 const mockRawAlert: DependabotAlert = {
   number: 1,
@@ -200,5 +200,33 @@ describe('fetchEnterpriseAlerts', () => {
     expect(mockListAlertsForEnterprise).toHaveBeenCalledWith(
       expect.objectContaining({ ecosystem: undefined }),
     )
+  })
+})
+
+describe('filterIgnoredAlerts', () => {
+  const alerts = [
+    { packageName: 'lodash', repository: { name: 'repo', owner: 'org' }, createdAt: '' },
+    { packageName: 'axios', repository: { name: 'repo', owner: 'org' }, createdAt: '' },
+    { packageName: 'express', repository: { name: 'repo', owner: 'org' }, createdAt: '' },
+  ]
+
+  it('returns all alerts when ignore list is empty', () => {
+    expect(filterIgnoredAlerts(alerts, [])).toHaveLength(3)
+  })
+
+  it('removes a single ignored package', () => {
+    const result = filterIgnoredAlerts(alerts, ['lodash'])
+    expect(result).toHaveLength(2)
+    expect(result.map((a) => a.packageName)).not.toContain('lodash')
+  })
+
+  it('removes multiple ignored packages', () => {
+    const result = filterIgnoredAlerts(alerts, ['lodash', 'axios'])
+    expect(result).toHaveLength(1)
+    expect(result[0].packageName).toBe('express')
+  })
+
+  it('returns all alerts when no packages match the ignore list', () => {
+    expect(filterIgnoredAlerts(alerts, ['moment'])).toHaveLength(3)
   })
 })


### PR DESCRIPTION
## Summary
- Add `ignore` input: comma-separated list of package names to exclude from notifications (e.g. `lodash,axios`)
- Filter is applied client-side after fetching, since the GitHub API has no native exclude-package parameter
- Extracted as `filterIgnoredAlerts` in `src/fetch-alerts.ts` for testability
- 4 new tests covering empty list, single match, multiple matches, and no matches

Closes #195

## Test plan
- [ ] `npm test` passes (62 tests across 9 files)
- [ ] `npm run build` passes with no type errors
- [ ] `npx eslint src/**/*.ts tests/**/*.ts` passes with no errors